### PR TITLE
Update set-output

### DIFF
--- a/.github/workflows/operator_pull_request.yaml
+++ b/.github/workflows/operator_pull_request.yaml
@@ -116,7 +116,7 @@ jobs:
       run: |
         sha=${{ github.event.pull_request.head.sha }}
         tag="SNAPSHOT-PR-${{ github.event.pull_request.number }}-${sha:0:8}"
-        echo "##[set-output name=GIT_TAG;]$(echo ${tag})"
+        echo "GIT_TAG=$(echo ${tag})" >> $GITHUB_OUTPUT
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2

--- a/.github/workflows/pull_request_container_build.yaml
+++ b/.github/workflows/pull_request_container_build.yaml
@@ -43,7 +43,7 @@ jobs:
         run: |
           sha=${{ github.event.pull_request.head.sha }}
           tag="SNAPSHOT-PR-${{ github.event.pull_request.number }}-${sha:0:8}"
-          echo "##[set-output name=GIT_TAG;]$(echo ${tag})"
+          echo "GIT_TAG=$(echo ${tag})" >> $GITHUB_OUTPUT
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2


### PR DESCRIPTION
`set-output` will be disabled by 31 May 2023: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/