### PR TITLE
Add the ability to provide Docker secrets

### DIFF
--- a/.github/workflows/pull_request_container_build.yaml
+++ b/.github/workflows/pull_request_container_build.yaml
@@ -12,6 +12,11 @@ on:
         default: ""
         required: false
         type: string
+      DOCKER_SECRETS:
+        description: Docker build secrets
+        default: ""
+        required: false
+        type: string
       BUILD_PARAMETERS:
         description: Docker build parameters
         default: ""
@@ -85,6 +90,7 @@ jobs:
           labels: |
             org.opencontainers.image.source=${{ github.event.repository.clone_url }}
             org.opencontainers.image.revision=${{ github.sha }}
+          secrets: ${{ inputs.DOCKER_SECRETS }}
 
       - name: Comment on PR
         uses: mshick/add-pr-comment@v2

--- a/.github/workflows/push_container_only.yaml
+++ b/.github/workflows/push_container_only.yaml
@@ -12,6 +12,11 @@ on:
         default: ""
         required: false
         type: string
+      DOCKER_SECRETS:
+        description: Docker build secrets
+        default: ""
+        required: false
+        type: string
       BUILD_PARAMETERS:
         description: Docker build parameters
         default: ""
@@ -79,6 +84,7 @@ jobs:
           labels: |
             org.opencontainers.image.source=${{ github.event.repository.clone_url }}
             org.opencontainers.image.revision=${{ github.sha }}
+          secrets: ${{ inputs.DOCKER_SECRETS }}
 
       - name: Comment on PR
         uses: mshick/add-pr-comment@v2


### PR DESCRIPTION
https://docs.docker.com/engine/reference/commandline/buildx_build/#secret

When using build contexts that use private GitHub repositories, it is necessary to specify `GIT_AUTH_TOKEN` secret for buildkit to read from the repo: https://github.com/moby/buildkit/blob/811b22e35c31cbe567f571562eba013b351a77c5/client/llb/source.go#L245