### PR TITLE
Update max-depth for link checking

### DIFF
--- a/.github/workflows/pull_request_doc_qa.yaml
+++ b/.github/workflows/pull_request_doc_qa.yaml
@@ -27,7 +27,7 @@ jobs:
           config-file: ${{inputs.MD_CONFIG}}
           use-quiet-mode: 'yes'
           use-verbose-mode: 'yes'
-          max-depth: 1
+          max-depth: 3
 
   spell_check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Docs are usually at least 3 directory levels deep