### PR TITLE
String substitution

### DIFF
--- a/.github/workflows/pull_request_closed.yaml
+++ b/.github/workflows/pull_request_closed.yaml
@@ -35,4 +35,4 @@ jobs:
       - name: Delete redundant PR deployment
         env:
           HEAD_REF: ${{ github.head_ref }}
-        run: mike delete --push -b pull-request-deployments $HEAD_REF
+        run: mike delete --push -b pull-request-deployments ${HEAD_REF//\//-}

--- a/.github/workflows/pull_request_versioned_doc.yaml
+++ b/.github/workflows/pull_request_versioned_doc.yaml
@@ -35,4 +35,4 @@ jobs:
       - name: Deploy PR docs
         env:
           HEAD_REF: ${{ github.head_ref }}
-        run: mike deploy --push -b pull-request-deployments $HEAD_REF
+        run: mike deploy --push -b pull-request-deployments ${HEAD_REF//\//-}


### PR DESCRIPTION
For versioned doc, when doing pull requests for Renovate PRs, it creates a temporary version with forward slash however mike doesn't allow forward slashes in versions. For example here https://github.com/stakater/mto-docs/actions/runs/4819621365/jobs/8583063348?pr=20 we get:
```sh
Run mike deploy --push -b pull-request-deployments $HEAD_REF
error: 'renovate/stakater-.github-0.x' is not a valid version
```

Do a bash string substitution, where we replace all matches of forward slash with dash:

```sh
> TEMP=renovate/with/many/slashes
> echo ${TEMP//\//-}
renovate-with-many-slashes
```