### PR TITLE
enabling submodule checkout, needed for mto-docs

### DIFF
--- a/.github/workflows/pull_request_container_build.yaml
+++ b/.github/workflows/pull_request_container_build.yaml
@@ -42,6 +42,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
         with:
+          submodules: recursive
           persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
           ref: ${{github.event.pull_request.head.sha}}


### PR DESCRIPTION
we have a submodule in a repo which does not checkout in workflow. need to enable submodule checkout.