### PR TITLE
Enable submodule checkout and adding new workflows for mkdocs related repos

### DIFF
--- a/.github/workflows/mkdocs_branch_deleted.yaml
+++ b/.github/workflows/mkdocs_branch_deleted.yaml
@@ -1,0 +1,61 @@
+name: Deleting a branch for versioned mkdocs
+
+on:
+  workflow_call:
+    secrets:
+      GH_TOKEN:
+        description: "GitHub token"
+        required: true
+
+jobs:
+  delete:
+    if: github.event.ref_type == 'branch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if the deleted branch is a version branch
+        id: branch_check
+        uses: MeilCli/regex-match@v1
+        with:
+          regex_pattern: '^[0-9]+\.[0-9]+(\.[0-9]+)?$'
+          search_string: ${{ github.event.ref }}
+
+      - name: Checkout source files
+        if: steps.branch_check.outputs.matched == 'true'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+          persist-credentials: true
+          token: ${{ secrets.GH_TOKEN }}
+
+      - name: Set up Python
+        if: steps.branch_check.outputs.matched == 'true'
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+
+      - name: Install mike
+        run: pip3 install mike
+
+      - name: Run prepare_theme.sh script from repository to merge theme_common and theme_override folders
+        run: |
+          chmod +x prepare_theme.sh
+          ./prepare_theme.sh
+
+      - name: Configure Git user
+        if: steps.branch_check.outputs.matched == 'true'
+        run: |
+          git config --local user.email "stakater@gmail.com"
+          git config --local user.name "stakater-user"
+
+      - name: Delete removed version
+        if: steps.branch_check.outputs.matched == 'true'
+        run: mike delete --push ${{ github.event.ref }}
+
+      - name: Push Latest Tag
+        if: steps.branch_check.outputs.matched == 'true'
+        uses: anothrNick/github-tag-action@1.61.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          WITH_V: true
+          DEFAULT_BUMP: patch

--- a/.github/workflows/mkdocs_pull_request_closed.yaml
+++ b/.github/workflows/mkdocs_pull_request_closed.yaml
@@ -1,0 +1,43 @@
+name: Closing a pull request for versioned mkdocs
+
+on:
+  workflow_call:
+    secrets:
+      GH_TOKEN:
+        description: "GitHub token"
+        required: true
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source files
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+          persist-credentials: true
+          token: ${{ secrets.GH_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+
+      - name: Install mike
+        run: pip3 install mike
+
+      - name: Run prepare_theme.sh script from repository to merge theme_common and theme_override folders
+        run: |
+          chmod +x prepare_theme.sh
+          ./prepare_theme.sh
+
+      - name: Configure Git user
+        run: |
+          git config --local user.email "stakater@gmail.com"
+          git config --local user.name "stakater-user"
+
+      - name: Delete redundant PR deployment
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: mike delete --push -b pull-request-deployments ${HEAD_REF//\//-}

--- a/.github/workflows/mkdocs_pull_request_versioned_doc.yaml
+++ b/.github/workflows/mkdocs_pull_request_versioned_doc.yaml
@@ -1,0 +1,43 @@
+name: Pull request for versioned mkdocs
+
+on:
+  workflow_call:
+    secrets:
+      GH_TOKEN:
+        description: "GitHub token"
+        required: true
+
+jobs:
+  deploy_doc:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source files
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+          persist-credentials: true
+          token: ${{ secrets.GH_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+
+      - name: Install mike
+        run: pip3 install mike
+
+      - name: Run prepare_theme.sh script from repository to merge theme_common and theme_override folders
+        run: |
+          chmod +x prepare_theme.sh
+          ./prepare_theme.sh
+
+      - name: Configure git user
+        run: |
+          git config --local user.email "stakater@gmail.com"
+          git config --local user.name "stakater-user"
+
+      - name: Deploy PR docs
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: mike deploy --push -b pull-request-deployments ${HEAD_REF//\//-}

--- a/.github/workflows/mkdocs_push_versioned_doc.yaml
+++ b/.github/workflows/mkdocs_push_versioned_doc.yaml
@@ -1,0 +1,54 @@
+name: Push versioned mkdocs
+
+on:
+  workflow_call:
+    secrets:
+      GH_TOKEN:
+        description: "GitHub token"
+        required: true
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source files
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+          persist-credentials: true
+          token: ${{ secrets.GH_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+
+      - name: Install mike
+        run: pip3 install mike
+
+      - name: Run prepare_theme.sh script from repository to merge theme_common and theme_override folders
+        run: |
+          chmod +x prepare_theme.sh
+          ./prepare_theme.sh
+
+      - name: Configure Git user
+        run: |
+          git config --local user.email "stakater@gmail.com"
+          git config --local user.name "stakater-user"
+
+      - name: Deploy content
+        run: mike deploy --push ${{ github.ref_name }}
+
+      - name: Set alias
+        run: mike alias --push main latest
+
+      - name: Set default doc version
+        run: mike set-default --push latest
+
+      - name: Push Latest Tag
+        uses: anothrNick/github-tag-action@1.61.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          WITH_V: true
+          DEFAULT_BUMP: patch

--- a/.github/workflows/pull_request_container_build.yaml
+++ b/.github/workflows/pull_request_container_build.yaml
@@ -42,6 +42,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
         with:
+          submodules: recursive
           persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
           ref: ${{github.event.pull_request.head.sha}}

--- a/.github/workflows/push_container_only.yaml
+++ b/.github/workflows/push_container_only.yaml
@@ -44,6 +44,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
         with:
+          submodules: recursive
           persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
         with:
+          submodules: recursive
           persist-credentials: false # otherwise your personal token will be used
           fetch-depth: 0 # otherwise you will fail to push refs to dest repo
 

--- a/.github/workflows/release_template.yaml
+++ b/.github/workflows/release_template.yaml
@@ -14,6 +14,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
         with:
+          submodules: recursive
           persist-credentials: false # otherwise your personal token will be used
           fetch-depth: 0 # otherwise you will fail to push refs to dest repo
 


### PR DESCRIPTION
Why new workflows? Because we have created a common mkdocs theme project which will be used in combination with existing mkdocs projects. We need to enable submodules download as well as some changes in existing workflows to run scripts.
We have not modified the existing workflows for docs because we do not want other docs projects to get affected while we roll out new way of mkdocs one by one. Once we have done the transition for all projects, we will remove the old workflows.