### PR TITLE
Pin vale version

### DIFF
--- a/.github/workflows/pull_request_doc_qa.yaml
+++ b/.github/workflows/pull_request_doc_qa.yaml
@@ -41,6 +41,7 @@ jobs:
       - name: Spell check
         uses: errata-ai/vale-action@v2.0.1
         with:
+          version: 2.30.0
           styles: https://github.com/errata-ai/write-good/releases/latest/download/write-good.zip
           files: ${{inputs.DOC_SRC}}
         env:


### PR DESCRIPTION
The Vale GitHub action has until now not been pinned to a particular version, so the latest version has always inadvertently been used. Vale had a major version update 10 h ago that broke all current pipelines. Pin the version to the last minor version, so we can do a controlled upgrade to the latest version.