### PR TITLE
Vale 3 migration

### DIFF
--- a/.github/workflows/pull_request_doc_qa.yaml
+++ b/.github/workflows/pull_request_doc_qa.yaml
@@ -42,6 +42,7 @@ jobs:
         uses: errata-ai/vale-action@v2.0.1
         with:
           version: 3.0.5
+          fail_on_error: true
           files: ${{inputs.DOC_SRC}}
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/pull_request_doc_qa.yaml
+++ b/.github/workflows/pull_request_doc_qa.yaml
@@ -41,8 +41,7 @@ jobs:
       - name: Spell check
         uses: errata-ai/vale-action@v2.0.1
         with:
-          version: 2.30.0
-          styles: https://github.com/errata-ai/write-good/releases/latest/download/write-good.zip
+          version: 3.0.5
           files: ${{inputs.DOC_SRC}}
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/pull_request_doc_qa.yaml
+++ b/.github/workflows/pull_request_doc_qa.yaml
@@ -38,14 +38,15 @@ jobs:
         with:
           ref: ${{github.event.pull_request.head.sha}}
           submodules: recursive
+      - name: Install Vale
+        run: |
+          wget https://github.com/errata-ai/vale/releases/download/v3.0.5/vale_3.0.5_Linux_64-bit.tar.gz -O vale.tar.gz
+          tar -xvzf vale.tar.gz vale
+          rm vale.tar.gz
       - name: Spell check
-        uses: errata-ai/vale-action@v2.0.1
-        with:
-          version: 3.0.5
-          fail_on_error: true
-          files: ${{inputs.DOC_SRC}}
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: |
+          ./vale sync
+          ./vale ${{inputs.DOC_SRC}}
 
   style_check:
     runs-on: ubuntu-latest

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,21 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:recommended"
+  ],
+  "labels": [
+    "dependencies"
+  ],
+  "customManagers": [
+    {
+        "customType": "regex",
+        "fileMatch": [
+            "\\.yaml$"
+        ],
+        "matchStrings": [
+            "https:\/\/github.com\/(?<depName>.*)\/releases\/download\/(?<currentValue>.*)\/.*.tar.gz"
+        ],
+        "datasourceTemplate": "github-release-attachments"
+    }
   ]
 }


### PR DESCRIPTION
Updates:
* Migrate to Vale 3
* Also switch to using Vale natively, because `reviewdog` does not treat errors as expected: https://github.com/errata-ai/vale-action/issues/116
* Add Renovate custom manager to update GitHub release attachments