### PR TITLE
Submodule checkout

### DIFF
--- a/.github/workflows/push_container.yaml
+++ b/.github/workflows/push_container.yaml
@@ -41,6 +41,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
         with:
+          submodules: recursive
           persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
 


### PR DESCRIPTION
Submodules are currently not checked out during container push, causing builds that depend on submodules to fail