### PR TITLE
Revert "Run go mod tidy in publish_operator_image_and_bundle.yaml workflow"

### DIFF
--- a/.github/workflows/publish_operator_image_and_bundle.yaml
+++ b/.github/workflows/publish_operator_image_and_bundle.yaml
@@ -262,9 +262,6 @@ jobs:
         IMAGE_DIGEST: ${{ needs.publish-image.outputs.operatorhub_image_digest }}
       run: make update-operator-hub-image-digest
 
-    - name: Run go mod tidy 
-      run: go mod tidy
-      
     - name: Update Bundle
       run: make bundle
 


### PR DESCRIPTION
Reverts stakater/.github#106