### PR TITLE
Change to generic github token

### DIFF
--- a/.github/workflows/publish_operator_image_and_bundle.yaml
+++ b/.github/workflows/publish_operator_image_and_bundle.yaml
@@ -31,12 +31,12 @@ on:
         description: Certification project ID
         required: true
         type: string
-      
+
       DOCKER_FILE_PATH:
         description: Dockerfile path
         required: true
         type: string
-      
+
       PUBLISH_BUNDLE:
         description: "Publish bundle will publish operator bundle to stakater/certified-operators"
         default: false
@@ -47,7 +47,7 @@ on:
         description: Admin user name to pull private repository
         required: false
         type: string
-      
+
       SUBPATH:
         description: Custom path for docker build
         required: true
@@ -86,10 +86,6 @@ on:
         description: "Pyxis API token to run Preflight"
         required: true
 
-      STAKATER_GITHUB_TOKEN:
-        description: "Secret to create branch in stakater/certified-operators repository"
-        required: false
-      
       ADMIN_TOKEN:
         description: "Secret to commit bundle files"
         required: false
@@ -158,7 +154,7 @@ jobs:
       run: |
         echo ${{ secrets.REGISTRY_REDHAT_IO_PULL_SECRET }} | base64 -d > ~/.docker/config.json
         docker login registry.redhat.io
-    
+
     # For pushing operator image
     - name: Login to Quay Registry
       uses: docker/login-action@v3
@@ -170,7 +166,7 @@ jobs:
     - name: Generate image repository path
       run: |
         echo IMAGE_REPOSITORY=$(echo quay.io/${{ secrets.OPERATORHUB_REPOSITORY }}) >> $GITHUB_ENV
-    
+
     # Build and push tag
     - name: Build and push
       id: build_and_push
@@ -191,7 +187,7 @@ jobs:
     - name: Run Preflight test
       run: |
         preflight check container ${{ env.IMAGE_REPOSITORY }}:${{ steps.latest_tag.outputs.tag }} --pyxis-api-token ${{ secrets.PYXIS_API_TOKEN }} --docker-config ~/.docker/config.json
-    
+
     - name: Submit Preflight test
       run: |
         rm -r ./artifacts
@@ -214,7 +210,7 @@ jobs:
         cache-to: type=inline
         tags: |
           ${{ env.IMAGE_REPOSITORY }}:latest
-    
+
     outputs:
       operatorhub_image_digest: ${{ steps.build_and_push.outputs.digest }}
       latest_tag: ${{ steps.latest_tag.outputs.tag }}
@@ -234,8 +230,8 @@ jobs:
 
     - name: Check if registry secrets are set
       run: |
-        if [ "${{ secrets.STAKATER_GITHUB_TOKEN }}" == "" ] || [ "${{ secrets.ADMIN_TOKEN }}" == "" ]; then
-          echo "Required Secrets 'STAKATER_GITHUB_TOKEN' or 'ADMIN_TOKEN' is not set!"
+        if [ "${{ secrets.ADMIN_TOKEN }}" == "" ]; then
+          echo "Required Secrets 'ADMIN_TOKEN' is not set!"
           exit 1
         fi
 
@@ -276,20 +272,16 @@ jobs:
 
     - name: Clone stakater/certified-operators repository
       run: |
-        if [ -z "${{ secrets.STAKATER_GITHUB_TOKEN }}" ]; then
-            git clone https://github.com/stakater/certified-operators.git
-        else
-            git clone https://${{ secrets.STAKATER_GITHUB_TOKEN }}@github.com/stakater/certified-operators.git
-        fi
-        
+        git clone https://${{ secrets.GITHUB_TOKEN }}@github.com/stakater/certified-operators.git
+
         if [ -d "certified-operators" ]; then
             echo "Cloned certified-operators repository successfully."
-            echo "Access the repository content using \"cd certified-operators\"." 
+            echo "Access the repository content using \"cd certified-operators\"."
         else
             echo "Error: Couldn't clone certified-operators repository. Check the inputs or the PAT scope."
             exit 1
         fi
-    
+
     - name: Push branch
       run: |
         cd certified-operators
@@ -306,13 +298,13 @@ jobs:
         git add .
         git commit -am "Updated multi-tenant-operator to ${{ needs.publish-image.outputs.latest_tag}}"
         git push --set-upstream origin mto-${{ needs.publish-image.outputs.latest_tag}}
-    
+
     - name: Push changes
       uses: ad-m/github-push-action@master
       with:
         github_token: ${{ secrets.ADMIN_TOKEN }}
         branch: main
-    
+
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
 
@@ -322,7 +314,7 @@ jobs:
         driver-opts: |
             image=moby/buildkit:v0.9.3
         buildkitd-flags: --debug
-    
+
     - name: Login to Nexus Registry
       uses: docker/login-action@v3
       with:
@@ -339,7 +331,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [publish-image, publish-bundle]
     if: always()
-    
+
     steps:
     - name: Notify Slack
       uses: 8398a7/action-slack@v3

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Push Latest Tag
         uses: anothrNick/github-tag-action@1.61.0
         env:
-          GITHUB_TOKEN: ${{ secrets.STAKATER_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WITH_V: true
           DEFAULT_BUMP: patch
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Create Release
         uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.STAKATER_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
           release_name: ${{ github.ref }}


### PR DESCRIPTION
From what I can see, a dedicated token is not needed, and the generic github token can be used instead