### PR TITLE
Need to change token to trigger release

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -7,7 +7,7 @@ on:
       - "main"
 
 jobs:
-  build:
+  push:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
@@ -17,9 +17,9 @@ jobs:
           fetch-depth: 0 # otherwise you will fail to push refs to dest repo
 
       - name: Push Latest Tag
-        uses: anothrNick/github-tag-action@1.61.0
+        uses: anothrNick/github-tag-action@1.67.0
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
           WITH_V: true
           DEFAULT_BUMP: patch
 


### PR DESCRIPTION
Need to change token: https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication
```
if a workflow run pushes code using the repository's GITHUB_TOKEN, a new workflow will not run even when the repository contains a workflow configured to run when push events occur.
```

Correct the job name.

Use later version of action, this should be safe to use, latest version doesn't work.