### PR TITLE
Image repository path

### DIFF
--- a/.github/workflows/pull_request_container_build.yaml
+++ b/.github/workflows/pull_request_container_build.yaml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Generate image repository path
         run: |
-          echo IMAGE_REPOSITORY=$(echo ${{ secrets.CONTAINER_REGISTRY_URL }}/${{ github.repository }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
+          echo IMAGE_REPOSITORY=$(echo ${{ secrets.CONTAINER_REGISTRY_URL }}/${{ github.event.repository.name }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
 
       - name: Build and push
         uses: docker/build-push-action@v6


### PR DESCRIPTION
Many PR images have been incorrectly published in a subfolder since `CONTAINER_REGISTRY_URL` already contains the subpath in the registry, for example PR images for mto-docs are currently published in `https://ghcr.io/stakater/stakater/mto-docs` when they should be in `https://ghcr.io/stakater/mto-docs`

Subsequent PRs need to update all uses of this template, so they use the correct value for `CONTAINER_REGISTRY_URL`