### PR TITLE
Enable setting latest doc version for multiple versioned doc

### DIFF
--- a/.github/workflows/branch_deleted.yaml
+++ b/.github/workflows/branch_deleted.yaml
@@ -2,15 +2,22 @@ name: Deleting a branch for versioned doc
 
 on:
   workflow_call:
+    inputs:
+      LATEST_DOC_VERSION:
+        description: Define the latest doc version for multiple versioned doc
+        required: true
+        type: string
     secrets:
       GH_TOKEN:
         description: "GitHub token"
         required: true
 
 jobs:
-  delete:
+  check:
     if: github.event.ref_type == 'branch'
     runs-on: ubuntu-latest
+    outputs:
+      matched: ${{ steps.branch_check.outputs.matched }}
     steps:
       - name: Check if the deleted branch is a version branch
         id: branch_check
@@ -18,9 +25,12 @@ jobs:
         with:
           regex_pattern: '^[0-9]+\.[0-9]+(\.[0-9]+)?$'
           search_string: ${{ github.event.ref }}
-
+  delete:
+    needs: check
+    if: needs.check.outputs.matched == 'true'
+    runs-on: ubuntu-latest
+    steps:
       - name: Checkout source files
-        if: steps.branch_check.outputs.matched == 'true'
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -29,33 +39,30 @@ jobs:
           token: ${{ secrets.GH_TOKEN }}
 
       - name: Set up Python
-        if: steps.branch_check.outputs.matched == 'true'
         uses: actions/setup-python@v5
         with:
           python-version: 3.11
 
       - name: Install mike
-        if: steps.branch_check.outputs.matched == 'true'
         run: pip3 install mike
 
       - name: Run prepare_theme.sh script from repository to merge theme_common and theme_override folders
-        if: steps.branch_check.outputs.matched == 'true'
         run: |
           chmod +x prepare_theme.sh
           ./prepare_theme.sh
 
       - name: Configure Git user
-        if: steps.branch_check.outputs.matched == 'true'
         run: |
           git config --local user.email "stakater@gmail.com"
           git config --local user.name "stakater-user"
 
-      - name: Delete removed version
-        if: steps.branch_check.outputs.matched == 'true'
+      - name: Delete the version and all its aliases from the branch
         run: mike delete --push ${{ github.event.ref }}
 
+      - name: Update 'latest' alias to latest doc version
+        run: mike alias --push --update-aliases ${{ inputs.LATEST_DOC_VERSION }} latest
+
       - name: Push Latest Tag
-        if: steps.branch_check.outputs.matched == 'true'
         uses: anothrNick/github-tag-action@1.61.0
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/push_versioned_doc.yaml
+++ b/.github/workflows/push_versioned_doc.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: Update 'latest' alias to latest doc version
         run: mike alias --push --update-aliases ${{ inputs.LATEST_DOC_VERSION }} latest
 
-      - name: Set default doc version to the latest alias
+      - name: When publishing a new version, always update the alias to point to the latest version
         run: mike set-default --push latest
 
       - name: Push Latest Tag

--- a/.github/workflows/push_versioned_doc.yaml
+++ b/.github/workflows/push_versioned_doc.yaml
@@ -42,10 +42,13 @@ jobs:
           git config --local user.email "stakater@gmail.com"
           git config --local user.name "stakater-user"
 
-      - name: Deploy content and update 'latest' alias to latest doc version
-        run: mike deploy --push ${{ github.ref_name }} --update-aliases ${{ inputs.LATEST_DOC_VERSION }} latest
+      - name: Deploy content
+        run: mike deploy --push ${{ github.ref_name }}
 
-      - name: Set default doc version
+      - name: Update 'latest' alias to latest doc version
+        run: mike alias --update-aliases ${{ inputs.LATEST_DOC_VERSION }} latest
+
+      - name: Set default doc version to the latest alias
         run: mike set-default --push latest
 
       - name: Push Latest Tag

--- a/.github/workflows/push_versioned_doc.yaml
+++ b/.github/workflows/push_versioned_doc.yaml
@@ -42,8 +42,8 @@ jobs:
           git config --local user.email "stakater@gmail.com"
           git config --local user.name "stakater-user"
 
-      - name: Deploy content, create an alias for same version being deployed, and update 'latest' alias to latest doc version
-        run: mike deploy --push ${{ github.ref_name }} ${{ github.ref_name }} --update-aliases ${{ inputs.LATEST_DOC_VERSION }} latest
+      - name: Deploy content and update 'latest' alias to latest doc version
+        run: mike deploy --push ${{ github.ref_name }} --update-aliases ${{ inputs.LATEST_DOC_VERSION }} latest
 
       - name: Set default doc version
         run: mike set-default --push latest

--- a/.github/workflows/push_versioned_doc.yaml
+++ b/.github/workflows/push_versioned_doc.yaml
@@ -2,6 +2,11 @@ name: Push versioned doc
 
 on:
   workflow_call:
+    inputs:
+      LATEST_DOC_VERSION:
+        description: Define the latest doc version for multiple versioned doc
+        required: true
+        type: string
     secrets:
       GH_TOKEN:
         description: "GitHub token"
@@ -37,11 +42,8 @@ jobs:
           git config --local user.email "stakater@gmail.com"
           git config --local user.name "stakater-user"
 
-      - name: Deploy content
-        run: mike deploy --push ${{ github.ref_name }}
-
-      - name: Set alias
-        run: mike alias --push main latest
+      - name: Deploy content, create an alias for same version being deployed, and update 'latest' alias to latest doc version
+        run: mike deploy --push ${{ github.ref_name }} ${{ github.ref_name }} --update-aliases ${{ inputs.LATEST_DOC_VERSION }} latest
 
       - name: Set default doc version
         run: mike set-default --push latest

--- a/.github/workflows/push_versioned_doc.yaml
+++ b/.github/workflows/push_versioned_doc.yaml
@@ -46,7 +46,7 @@ jobs:
         run: mike deploy --push ${{ github.ref_name }}
 
       - name: Update 'latest' alias to latest doc version
-        run: mike alias --update-aliases ${{ inputs.LATEST_DOC_VERSION }} latest
+        run: mike alias --push --update-aliases ${{ inputs.LATEST_DOC_VERSION }} latest
 
       - name: Set default doc version to the latest alias
         run: mike set-default --push latest

--- a/.github/workflows/rdlm_acquire.yaml
+++ b/.github/workflows/rdlm_acquire.yaml
@@ -17,21 +17,21 @@ on:
         description: "Wait time for the resource to acquire"
         required: true
         type: string
-      
+
       RDLM_URL:
         description: "Service path of the RDLM server running on the cluster"
         required: true
         type: string
-      
+
 jobs:
   acquire-resource:
     name: Acquire lock
     runs-on: ${{ inputs.RESOURCE_NAME }}
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      
+
       - name: Run acquire.sh
         env:
           RDLM_URL: ${{ inputs.RDLM_URL }}

--- a/.github/workflows/rdlm_release.yaml
+++ b/.github/workflows/rdlm_release.yaml
@@ -6,21 +6,21 @@ on:
         description: "Name of the resource to release"
         required: true
         type: string
-      
+
       RDLM_URL:
         description: "Service path of the RDLM server running on the cluster"
         required: true
         type: string
-      
+
 jobs:
   release-resource:
     name: Release lock
     runs-on: ${{ inputs.RESOURCE_NAME }}
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      
+
       - name: Run release.sh
         env:
           RDLM_URL: ${{ inputs.RDLM_URL }}


### PR DESCRIPTION
When viewing versioned documentation, and selecting a version that is not the latest, the banner warning about not being on the latest version should only display when the user has not selected the latest released version. Currently, it treats `main` as the latest version, but `main` should not be the `latest` alias - instead, the versioned doc pipeline should always require to specify which version is the latest, and the `latest` alias should be updated to be based on the latest doc version provided.

For example, `versions.json` could look like this:

```json
[
  {
    "version": "main",
    "title": "main",
    "aliases": [
      "latest"
    ]
  },
  {
    "version": "1.0",
    "title": "1.0",
    "aliases": []
  }
]
```

When the versioned doc pipeline builds the docs for any version, and it specifies `1.0` as the latest version, the JSON is expected to look like this after a run:

```json
[
  {
    "version": "main",
    "title": "main",
    "aliases": []
  },
  {
    "version": "1.0",
    "title": "1.0",
    "aliases": [
      "latest"
    ]
  }
]
```

The changes in this PR has been tested locally with `mike` on a temporary `test` branch in the [`mto-docs`](https://github.com/stakater/mto-docs) repo and it seems to work as expected for different CRUD scenarios:

* CREATE
  * When no docs exist at all, and a particular version is built, the `latest` alias can be pushed and updated for that same version
  * When more versions are built, the `latest` alias remains with the version specified
* READ
  * No applicable use case
* UPDATE
  * When a previously existing version is built again, the `latest` alias remains with the version specified
* DELETE
  * If deleting a version that is aliased as latest, the `latest` alias also gets deleted and doesn't get reassigned anywhere, so it needs to be updated as part of the delete pipeline