### PR TITLE
When deploying PR builds, update latest alias

### DIFF
--- a/.github/workflows/pull_request_versioned_doc.yaml
+++ b/.github/workflows/pull_request_versioned_doc.yaml
@@ -57,6 +57,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          message-success: "@${{ github.actor }} Doc deploy will soon be available on https://stakater.github.io/mto-docs/${CURRENT_BRANCH}"
-          message-failure: "@${{ github.actor }} Doc deploy failed!"
+          message-success: "@${{ github.actor }} PR doc deploy will soon be available for review on https://stakater.github.io/mto-docs/${CURRENT_BRANCH}"
+          message-failure: "@${{ github.actor }} PR doc deploy failed!"
           allow-repeats: true

--- a/.github/workflows/pull_request_versioned_doc.yaml
+++ b/.github/workflows/pull_request_versioned_doc.yaml
@@ -7,6 +7,10 @@ on:
         description: "GitHub token"
         required: true
 
+env:
+  # Store the current head ref as a url friendly variable
+  CURRENT_BRANCH: ${HEAD_REF//\//-}
+
 jobs:
   deploy_doc:
     runs-on: ubuntu-latest
@@ -40,10 +44,19 @@ jobs:
       - name: Deploy PR docs
         env:
           HEAD_REF: ${{ github.head_ref }}
-        run: mike deploy --push -b pull-request-deployments ${HEAD_REF//\//-}
+        run: mike deploy --push -b pull-request-deployments $CURRENT_BRANCH
 
       - name: Update 'latest' alias to latest PR build
-        run: mike alias --push -b pull-request-deployments --update-aliases ${HEAD_REF//\//-} latest
+        run: mike alias --push -b pull-request-deployments --update-aliases $CURRENT_BRANCH latest
 
       - name: When publishing a new version, always update the alias to point to the latest version
         run: mike set-default --push -b pull-request-deployments latest
+
+      - name: Comment on PR
+        uses: mshick/add-pr-comment@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          message-success: "@${{ github.actor }} Doc deploy will soon be available on https://stakater.github.io/mto-docs/${CURRENT_BRANCH}"
+          message-failure: "@${{ github.actor }} Doc deploy failed!"
+          allow-repeats: true

--- a/.github/workflows/pull_request_versioned_doc.yaml
+++ b/.github/workflows/pull_request_versioned_doc.yaml
@@ -41,3 +41,9 @@ jobs:
         env:
           HEAD_REF: ${{ github.head_ref }}
         run: mike deploy --push -b pull-request-deployments ${HEAD_REF//\//-}
+
+      - name: Update 'latest' alias to latest PR build
+        run: mike alias --push -b pull-request-deployments --update-aliases ${HEAD_REF//\//-} latest
+
+      - name: When publishing a new version, always update the alias to point to the latest version
+        run: mike set-default --push -b pull-request-deployments latest


### PR DESCRIPTION
* When deploying PR builds, update latest alias and set default. Otherwise, the root url will just return 404, and the user has to manually add the PR branch in the path to view the PR docs
* Add a comment in the PR pointing to where the docs are deployed for easy review