### PR TITLE
Fix head ref variable

### DIFF
--- a/.github/workflows/pull_request_closed.yaml
+++ b/.github/workflows/pull_request_closed.yaml
@@ -20,10 +20,12 @@ jobs:
           token: ${{ secrets.GH_TOKEN }}
 
       - name: Store the current head ref as a url friendly variable
+        id: current_branch
         env:
           HEAD_REF: ${{ github.head_ref }}
         run: |
-          CURRENT_BRANCH=$(echo ${HEAD_REF} | sed -e 's/[]:@\/?&=#%+[\!$()*,;]/-/g')
+          url_friendly_branch=$(echo ${HEAD_REF} | sed -e 's/[]:@\/?&=#%+[\!$()*,;]/-/g')
+          echo "CURRENT_BRANCH=$(echo ${url_friendly_branch})" >> $GITHUB_OUTPUT
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -44,7 +46,7 @@ jobs:
           git config --local user.name "stakater-user"
 
       - name: Delete redundant PR deployment
-        run: mike delete --push -b pull-request-deployments $CURRENT_BRANCH
+        run: mike delete --push -b pull-request-deployments ${{ steps.current_branch.outputs.CURRENT_BRANCH }}
 
       - name: Comment on PR
         uses: mshick/add-pr-comment@v2

--- a/.github/workflows/pull_request_closed.yaml
+++ b/.github/workflows/pull_request_closed.yaml
@@ -19,6 +19,12 @@ jobs:
           persist-credentials: true
           token: ${{ secrets.GH_TOKEN }}
 
+      - name: Store the current head ref as a url friendly variable
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          CURRENT_BRANCH=$(echo ${HEAD_REF} | sed -e 's/[]:@\/?&=#%+[\!$()*,;]/-/g')
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -27,10 +33,10 @@ jobs:
       - name: Install mike
         run: pip3 install mike
 
-      - name: Run prepare_theme.sh script from repository to merge theme_common and theme_override folders
+      - name: Run prepare_theme_pr.sh script from repository to merge theme_common and theme_override folders
         run: |
-          chmod +x prepare_theme.sh
-          ./prepare_theme.sh
+          chmod +x prepare_theme_pr.sh
+          ./prepare_theme_pr.sh
 
       - name: Configure Git user
         run: |
@@ -38,6 +44,13 @@ jobs:
           git config --local user.name "stakater-user"
 
       - name: Delete redundant PR deployment
+        run: mike delete --push -b pull-request-deployments $CURRENT_BRANCH
+
+      - name: Comment on PR
+        uses: mshick/add-pr-comment@v2
         env:
-          HEAD_REF: ${{ github.head_ref }}
-        run: mike delete --push -b pull-request-deployments ${HEAD_REF//\//-}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          message-success: "@${{ github.actor }} PR doc deploy was successfully deleted from branch pull-request-deployments"
+          message-failure: "@${{ github.actor }} PR doc deploy failed to be deleted on branch pull-request-deployments!"
+          allow-repeats: true

--- a/.github/workflows/pull_request_versioned_doc.yaml
+++ b/.github/workflows/pull_request_versioned_doc.yaml
@@ -20,10 +20,12 @@ jobs:
           token: ${{ secrets.GH_TOKEN }}
 
       - name: Store the current head ref as a url friendly variable
+        id: current_branch
         env:
           HEAD_REF: ${{ github.head_ref }}
         run: |
-          CURRENT_BRANCH=$(echo ${HEAD_REF} | sed -e 's/[]:@\/?&=#%+[\!$()*,;]/-/g')
+          url_friendly_branch=$(echo ${HEAD_REF} | sed -e 's/[]:@\/?&=#%+[\!$()*,;]/-/g')
+          echo "CURRENT_BRANCH=$(echo ${url_friendly_branch})" >> $GITHUB_OUTPUT
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -44,10 +46,10 @@ jobs:
           git config --local user.name "stakater-user"
 
       - name: Deploy PR docs
-        run: mike deploy --push -b pull-request-deployments $CURRENT_BRANCH
+        run: mike deploy --push -b pull-request-deployments ${{ steps.current_branch.outputs.CURRENT_BRANCH }}
 
       - name: Update 'latest' alias to latest PR build
-        run: mike alias --push -b pull-request-deployments --update-aliases $CURRENT_BRANCH latest
+        run: mike alias --push -b pull-request-deployments --update-aliases ${{ steps.current_branch.outputs.CURRENT_BRANCH }} latest
 
       - name: When publishing a new version, always update the alias to point to the latest version
         run: mike set-default --push -b pull-request-deployments latest
@@ -57,6 +59,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          message-success: "@${{ github.actor }} PR doc deploy will soon be available for review on https://stakater.github.io/mto-docs/${CURRENT_BRANCH}"
+          message-success: "@${{ github.actor }} PR doc deploy will soon be available for review on https://stakater.github.io/mto-docs/${{ steps.current_branch.outputs.CURRENT_BRANCH }}"
           message-failure: "@${{ github.actor }} PR doc deploy failed!"
           allow-repeats: true

--- a/.github/workflows/pull_request_versioned_doc.yaml
+++ b/.github/workflows/pull_request_versioned_doc.yaml
@@ -7,10 +7,6 @@ on:
         description: "GitHub token"
         required: true
 
-env:
-  # Store the current head ref as a url friendly variable
-  CURRENT_BRANCH: ${HEAD_REF//\//-}
-
 jobs:
   deploy_doc:
     runs-on: ubuntu-latest
@@ -22,6 +18,12 @@ jobs:
           submodules: recursive
           persist-credentials: true
           token: ${{ secrets.GH_TOKEN }}
+
+      - name: Store the current head ref as a url friendly variable
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          CURRENT_BRANCH=$(echo ${HEAD_REF} | sed -e 's/[]:@\/?&=#%+[\!$()*,;]/-/g')
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -42,8 +44,6 @@ jobs:
           git config --local user.name "stakater-user"
 
       - name: Deploy PR docs
-        env:
-          HEAD_REF: ${{ github.head_ref }}
         run: mike deploy --push -b pull-request-deployments $CURRENT_BRANCH
 
       - name: Update 'latest' alias to latest PR build


### PR DESCRIPTION
When deploying a PR branch, it currently fails with:

```txt
error: '${HEAD_REF//\\//-}' is not a valid version
Error: Process completed with exit code 1.
```

The fix in this PR was tested successfully in https://github.com/stakater/mto-docs/pull/208/commits/f9f8ba58b7107177fb12b803a7237b3218f95c52