### PR TITLE
Update markdown linter

### DIFF
--- a/.github/workflows/pull_request_doc_qa.yaml
+++ b/.github/workflows/pull_request_doc_qa.yaml
@@ -69,9 +69,14 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{github.event.pull_request.head.sha}}
+      - name: Convert the spaces in the doc source input to newlines
+        id: doc_src_newlines
+        run: |
+          doc_src_newlines=$(echo ${{inputs.DOC_SRC}} | sed -e 's/ /\n/g')
+          echo "DOC_SRC_NEWLINES=$(echo ${doc_src_newlines})" >> $GITHUB_OUTPUT
       - name: markdown linting check
         uses: DavidAnson/markdownlint-cli2-action@v18.0.0
         with:
-          globs: ${{inputs.DOC_SRC}}
-          separator: ' '
+          globs: |
+            ${{ steps.doc_src_newlines.outputs.DOC_SRC_NEWLINES }}
           config: ${{inputs.MD_LINT_CONFIG}}

--- a/.github/workflows/pull_request_doc_qa.yaml
+++ b/.github/workflows/pull_request_doc_qa.yaml
@@ -73,5 +73,4 @@ jobs:
         uses: DavidAnson/markdownlint-cli2-action@v18.0.0
         with:
           globs: ${{inputs.DOC_SRC}}
-          separator: ','
           config: ${{inputs.MD_LINT_CONFIG}}

--- a/.github/workflows/pull_request_doc_qa.yaml
+++ b/.github/workflows/pull_request_doc_qa.yaml
@@ -3,16 +3,16 @@ name: Documentation Quality Assurance
 on:
   workflow_call:
     inputs:
-      MD_CONFIG:
-        description: Markdown link checker config file
+      DOC_SRC:
+        description: Documentation source
         required: true
         type: string
-      DOC_SRC:
-        description: Documentation directory
+      MD_CONFIG:
+        description: Markdown link-checker configuration file
         required: true
         type: string
       MD_LINT_CONFIG:
-        description: Markdown lint config file
+        description: Markdown linting configuration file
         required: true
         type: string
 
@@ -73,4 +73,5 @@ jobs:
         uses: DavidAnson/markdownlint-cli2-action@v18.0.0
         with:
           globs: ${{inputs.DOC_SRC}}
+          separator: ' '
           config: ${{inputs.MD_LINT_CONFIG}}

--- a/.github/workflows/pull_request_doc_qa.yaml
+++ b/.github/workflows/pull_request_doc_qa.yaml
@@ -73,7 +73,7 @@ jobs:
         id: doc_src_newlines
         run: |
           doc_src_newlines=$(echo "${{inputs.DOC_SRC}}" | sed -e 's/ /\n/g')
-          echo "DOC_SRC_NEWLINES=$(echo ${doc_src_newlines})" >> $GITHUB_OUTPUT
+          echo "DOC_SRC_NEWLINES=$(echo "${doc_src_newlines}")" >> $GITHUB_OUTPUT
       - name: markdown linting check
         uses: DavidAnson/markdownlint-cli2-action@v18.0.0
         with:

--- a/.github/workflows/pull_request_doc_qa.yaml
+++ b/.github/workflows/pull_request_doc_qa.yaml
@@ -73,7 +73,9 @@ jobs:
         id: doc_src_newlines
         run: |
           doc_src_newlines=$(echo "${{inputs.DOC_SRC}}" | sed -e 's/ /\n/g')
-          echo "DOC_SRC_NEWLINES=$(echo "${doc_src_newlines}")" >> $GITHUB_OUTPUT
+          echo 'DOC_SRC_NEWLINES<<EOF' >> $GITHUB_OUTPUT
+          echo "${doc_src_newlines}" >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
       - name: markdown linting check
         uses: DavidAnson/markdownlint-cli2-action@v18.0.0
         with:

--- a/.github/workflows/pull_request_doc_qa.yaml
+++ b/.github/workflows/pull_request_doc_qa.yaml
@@ -72,7 +72,7 @@ jobs:
       - name: Convert the spaces in the doc source input to newlines
         id: doc_src_newlines
         run: |
-          doc_src_newlines=$(echo ${{inputs.DOC_SRC}} | sed -e 's/ /\n/g')
+          doc_src_newlines=$(echo "${{inputs.DOC_SRC}}" | sed -e 's/ /\n/g')
           echo "DOC_SRC_NEWLINES=$(echo ${doc_src_newlines})" >> $GITHUB_OUTPUT
       - name: markdown linting check
         uses: DavidAnson/markdownlint-cli2-action@v18.0.0

--- a/.github/workflows/pull_request_doc_qa.yaml
+++ b/.github/workflows/pull_request_doc_qa.yaml
@@ -73,5 +73,5 @@ jobs:
         uses: DavidAnson/markdownlint-cli2-action@v18.0.0
         with:
           globs: ${{inputs.DOC_SRC}}
-          separator: ' '
+          separator: ','
           config: ${{inputs.MD_LINT_CONFIG}}

--- a/.github/workflows/pull_request_doc_qa.yaml
+++ b/.github/workflows/pull_request_doc_qa.yaml
@@ -69,8 +69,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{github.event.pull_request.head.sha}}
-      - name: markdownlint-cli
-        uses: nosborn/github-action-markdown-cli@v3.3.0
+      - name: markdown linting check
+        uses: DavidAnson/markdownlint-cli2-action@v18.0.0
         with:
-          files: ${{inputs.DOC_SRC}}
-          config_file: ${{inputs.MD_LINT_CONFIG}}
+          globs: ${{inputs.DOC_SRC}}
+          separator: ' '
+          config: ${{inputs.MD_LINT_CONFIG}}


### PR DESCRIPTION
`nosborn/github-action-markdown-cli` is not very active and seems to ignore errors sometimes, switch to a more actively maintained action for running the linter. Both actions rely on the same [markdownlint](https://github.com/DavidAnson/markdownlint).

Tested successfully in https://github.com/stakater/saap-docs/pull/342/commits/4bcb1d5e4307e210e74b748f7ec5d00fab1245ee

The only update that is needed when using this template is that you need to be more specific when specifying the doc source, for example from:

```yaml
DOC_SRC: content README.md
```

to:

```yaml
DOC_SRC: content/**/*.md README.md
```