### PR TITLE
Fix bug with empty image path

### DIFF
--- a/.github/workflows/pull_request_container_build.yaml
+++ b/.github/workflows/pull_request_container_build.yaml
@@ -37,15 +37,27 @@ on:
       IMAGE_PATH:
         description: "The path of the image created"
         value: ${{ jobs.build.outputs.image_output }}
-      TEST:
-        value: ${{ jobs.build.outputs.test }}
+      TEST1:
+        value: ${{ jobs.build.outputs.test1 }}
+      TEST2:
+        value: ${{ jobs.build.outputs.test2 }}
+      TEST3:
+        value: ${{ jobs.build.outputs.test3 }}
+      TEST4:
+        value: ${{ jobs.build.outputs.test4 }}
+      TEST5:
+        value: ${{ jobs.build.outputs.test5 }}
 
 jobs:
   build:
     runs-on: ubuntu-latest
     outputs:
       image_output: ${{ steps.set_output.outputs.IMAGE_PATH }}
-      test: "testing"
+      test1: "testing"
+      test2: ${{ secrets.CONTAINER_REGISTRY_URL }}
+      test3: ${{ github.event.repository.name }}
+      test4: "${{ secrets.CONTAINER_REGISTRY_URL }}/${{ github.event.repository.name }}"
+      test5: "${{ steps.set_output.outputs.IMAGE_PATH }}"
     if: "! contains(toJSON(github.event.commits.*.message), '[skip-ci]')"
     steps:
       - name: Check out code

--- a/.github/workflows/pull_request_container_build.yaml
+++ b/.github/workflows/pull_request_container_build.yaml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Generate image path
         id: set_output
-        run: echo "IMAGE_PATH=TEST:${{ steps.generate_tag.outputs.GIT_TAG }}" >> $GITHUB_OUTPUT
+        run: echo "IMAGE_PATH=${{ secrets.CONTAINER_REGISTRY_URL }}/${{ github.event.repository.name }}:${{ steps.generate_tag.outputs.GIT_TAG }}" >> $GITHUB_OUTPUT
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/pull_request_container_build.yaml
+++ b/.github/workflows/pull_request_container_build.yaml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Generate image path
         id: set_output
-        run: echo "IMAGE_PATH=ghcr.io/stakater/${{ github.event.repository.name }}:${{ steps.generate_tag.outputs.GIT_TAG }}" >> $GITHUB_OUTPUT
+        run: echo "IMAGE_PATH=ghcr.io/stakater/handbook:${{ steps.generate_tag.outputs.GIT_TAG }}" >> $GITHUB_OUTPUT
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/pull_request_container_build.yaml
+++ b/.github/workflows/pull_request_container_build.yaml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Generate image path
         id: set_output
-        run: echo "IMAGE_PATH=${{ secrets.CONTAINER_REGISTRY_URL }}/handbook:${{ steps.generate_tag.outputs.GIT_TAG }}" >> $GITHUB_OUTPUT
+        run: echo "IMAGE_PATH=ghcr.io/stakater/${{ github.event.repository.name }}:${{ steps.generate_tag.outputs.GIT_TAG }}" >> $GITHUB_OUTPUT
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/pull_request_container_build.yaml
+++ b/.github/workflows/pull_request_container_build.yaml
@@ -37,12 +37,15 @@ on:
       IMAGE_PATH:
         description: "The path of the image created"
         value: ${{ jobs.build.outputs.image_output }}
+      TEST:
+        value: ${{ jobs.build.outputs.test }}
 
 jobs:
   build:
     runs-on: ubuntu-latest
     outputs:
       image_output: ${{ steps.set_output.outputs.IMAGE_PATH }}
+      test: "testing"
     if: "! contains(toJSON(github.event.commits.*.message), '[skip-ci]')"
     steps:
       - name: Check out code

--- a/.github/workflows/pull_request_container_build.yaml
+++ b/.github/workflows/pull_request_container_build.yaml
@@ -96,7 +96,7 @@ jobs:
           build-args: BUILD_PARAMETERS=${{ inputs.BUILD_PARAMETERS }}
           cache-to: type=inline
           tags: |
-            ${{ steps.generate_tag.outputs.image_repo_path }}:${{ steps.generate_tag.outputs.GIT_TAG }}
+            ${{ steps.image_repo_path.outputs.IMAGE_REPOSITORY }}:${{ steps.generate_tag.outputs.GIT_TAG }}
           labels: |
             org.opencontainers.image.source=${{ github.event.repository.clone_url }}
             org.opencontainers.image.revision=${{ github.sha }}
@@ -107,7 +107,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          message-success: '@${{ github.actor }} Image is available for testing. `docker pull ${{ steps.generate_tag.outputs.image_repo_path }}:${{ steps.generate_tag.outputs.GIT_TAG }}`'
+          message-success: '@${{ github.actor }} Image is available for testing. `docker pull ${{ steps.image_repo_path.outputs.IMAGE_REPOSITORY }}:${{ steps.generate_tag.outputs.GIT_TAG }}`'
           message-failure: '@${{ github.actor }} Yikes! You better fix it before anyone else finds out! [Build](https://github.com/${{ github.repository }}/commit/${{ github.event.pull_request.head.sha }}/checks) has Failed!'
           allow-repeats: true
 

--- a/.github/workflows/pull_request_container_build.yaml
+++ b/.github/workflows/pull_request_container_build.yaml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Generate image path
         id: set_output
-        run: echo "IMAGE_PATH=${{ steps.image_repo_path.outputs.IMAGE_REPOSITORY }}:${{ steps.generate_tag.outputs.GIT_TAG }}" >> $GITHUB_OUTPUT
+        run: echo "IMAGE_PATH=TEST:${{ steps.generate_tag.outputs.GIT_TAG }}" >> $GITHUB_OUTPUT
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/pull_request_container_build.yaml
+++ b/.github/workflows/pull_request_container_build.yaml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Generate image path
         id: set_output
-        run: echo "IMAGE_PATH=ghcr.io/stakater/handbook:${{ steps.generate_tag.outputs.GIT_TAG }}" >> $GITHUB_OUTPUT
+        run: echo "IMAGE_PATH=${{ steps.image_repo_path.outputs.IMAGE_REPOSITORY }}:${{ steps.generate_tag.outputs.GIT_TAG }}" >> $GITHUB_OUTPUT
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -99,7 +99,7 @@ jobs:
           build-args: BUILD_PARAMETERS=${{ inputs.BUILD_PARAMETERS }}
           cache-to: type=inline
           tags: |
-            ${{ steps.image_repo_path.outputs.IMAGE_REPOSITORY }}:${{ steps.generate_tag.outputs.GIT_TAG }}
+            ${{ steps.set_output.outputs.IMAGE_PATH }}
           labels: |
             org.opencontainers.image.source=${{ github.event.repository.clone_url }}
             org.opencontainers.image.revision=${{ github.sha }}
@@ -110,7 +110,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          message-success: '@${{ github.actor }} Image is available for testing. `docker pull ${{ steps.image_repo_path.outputs.IMAGE_REPOSITORY }}:${{ steps.generate_tag.outputs.GIT_TAG }}`'
+          message-success: '@${{ github.actor }} Image is available for testing. `docker pull ${{ steps.set_output.outputs.IMAGE_PATH }}`'
           message-failure: '@${{ github.actor }} Yikes! You better fix it before anyone else finds out! [Build](https://github.com/${{ github.repository }}/commit/${{ github.event.pull_request.head.sha }}/checks) has Failed!'
           allow-repeats: true
 

--- a/.github/workflows/pull_request_container_build.yaml
+++ b/.github/workflows/pull_request_container_build.yaml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Generate image path
         id: set_output
-        run: echo "IMAGE_PATH=${{ secrets.CONTAINER_REGISTRY_URL }}/${{ github.event.repository.name }}:${{ steps.generate_tag.outputs.GIT_TAG }}" >> $GITHUB_OUTPUT
+        run: echo "IMAGE_PATH=${{ secrets.CONTAINER_REGISTRY_URL }}/handbook:${{ steps.generate_tag.outputs.GIT_TAG }}" >> $GITHUB_OUTPUT
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/pull_request_container_build.yaml
+++ b/.github/workflows/pull_request_container_build.yaml
@@ -17,10 +17,11 @@ on:
         default: ""
         required: false
         type: string
-    secrets:
       CONTAINER_REGISTRY_URL:
         description: "Container registry to publish docker image"
         required: true
+        type: string
+    secrets:
       CONTAINER_REGISTRY_USERNAME:
         description: "Username to login to container registry"
         required: true
@@ -37,27 +38,12 @@ on:
       IMAGE_PATH:
         description: "The path of the image created"
         value: ${{ jobs.build.outputs.image_output }}
-      TEST1:
-        value: ${{ jobs.build.outputs.test1 }}
-      TEST2:
-        value: ${{ jobs.build.outputs.test2 }}
-      TEST3:
-        value: ${{ jobs.build.outputs.test3 }}
-      TEST4:
-        value: ${{ jobs.build.outputs.test4 }}
-      TEST5:
-        value: ${{ jobs.build.outputs.test5 }}
 
 jobs:
   build:
     runs-on: ubuntu-latest
     outputs:
       image_output: ${{ steps.set_output.outputs.IMAGE_PATH }}
-      test1: "testing"
-      test2: ${{ secrets.CONTAINER_REGISTRY_URL }}
-      test3: ${{ github.event.repository.name }}
-      test4: "${{ secrets.CONTAINER_REGISTRY_URL }}/${{ github.event.repository.name }}"
-      test5: "${{ steps.set_output.outputs.IMAGE_PATH }}"
     if: "! contains(toJSON(github.event.commits.*.message), '[skip-ci]')"
     steps:
       - name: Check out code
@@ -71,7 +57,7 @@ jobs:
       - name: Generate image repository path
         id: image_repo_path
         run: |
-          echo "IMAGE_REPOSITORY=$(echo ${{ secrets.CONTAINER_REGISTRY_URL }}/${{ github.event.repository.name }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
+          echo "IMAGE_REPOSITORY=$(echo ${{ inputs.CONTAINER_REGISTRY_URL }}/${{ github.event.repository.name }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
 
       - name: Generate image tag
         id: generate_tag
@@ -96,7 +82,7 @@ jobs:
       - name: Login to Registry
         uses: docker/login-action@v3
         with:
-          registry: ${{ secrets.CONTAINER_REGISTRY_URL }}
+          registry: ${{ inputs.CONTAINER_REGISTRY_URL }}
           username: ${{ secrets.CONTAINER_REGISTRY_USERNAME }}
           password: ${{ secrets.CONTAINER_REGISTRY_PASSWORD }}
 

--- a/.github/workflows/pull_request_container_build.yaml
+++ b/.github/workflows/pull_request_container_build.yaml
@@ -96,7 +96,7 @@ jobs:
           build-args: BUILD_PARAMETERS=${{ inputs.BUILD_PARAMETERS }}
           cache-to: type=inline
           tags: |
-            ${{ steps.set_output.outputs.IMAGE_PATH }}
+            ${{ steps.generate_tag.outputs.image_repo_path }}:${{ steps.generate_tag.outputs.GIT_TAG }}
           labels: |
             org.opencontainers.image.source=${{ github.event.repository.clone_url }}
             org.opencontainers.image.revision=${{ github.sha }}
@@ -107,7 +107,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          message-success: '@${{ github.actor }} Image is available for testing. `docker pull ${{ steps.set_output.outputs.IMAGE_PATH }}`'
+          message-success: '@${{ github.actor }} Image is available for testing. `docker pull ${{ steps.generate_tag.outputs.image_repo_path }}:${{ steps.generate_tag.outputs.GIT_TAG }}`'
           message-failure: '@${{ github.actor }} Yikes! You better fix it before anyone else finds out! [Build](https://github.com/${{ github.repository }}/commit/${{ github.event.pull_request.head.sha }}/checks) has Failed!'
           allow-repeats: true
 


### PR DESCRIPTION
The `IMAGE_PATH` output is all empty right now, and that is because it contains `CONTAINER_REGISTRY_URL` which is a secret, and secrets cannot be passed around between jobs. There are ways to pass around secrets by encoding and decoding them, using actions such as https://github.com/cloudposse/github-action-secret-outputs, but the registry URL doesn't need to be a secret anyway and can be passed around in clear text as an input. We always specify the secret as clear text anyway in our current workflows.