### PR TITLE
Get branch as output for versioned doc

### DIFF
--- a/.github/workflows/pull_request_versioned_doc.yaml
+++ b/.github/workflows/pull_request_versioned_doc.yaml
@@ -6,10 +6,16 @@ on:
       GH_TOKEN:
         description: "GitHub token"
         required: true
+    outputs:
+      CURRENT_BRANCH:
+        description: "Current head ref as a url friendly variable"
+        value: ${{ jobs.deploy_doc.outputs.current_branch }}
 
 jobs:
   deploy_doc:
     runs-on: ubuntu-latest
+    outputs:
+      current_branch: ${{ steps.current_branch.outputs.CURRENT_BRANCH }}
     steps:
       - name: Checkout source files
         uses: actions/checkout@v4


### PR DESCRIPTION
When creating PRs for versioned doc, we want to run tests as part of the pipeline, and then we need the branch name that will be used to set the version in the temporarily built docs as output from the pipeline