### PR TITLE
Rerun linkcheck if it fails

### DIFF
--- a/.github/workflows/pull_request_doc_qa.yaml
+++ b/.github/workflows/pull_request_doc_qa.yaml
@@ -29,7 +29,7 @@ jobs:
           action: gaurav-nelson/github-action-markdown-link-check@v1
           retry_condition: steps._this.conclusion == 'failure'
           attempt_limit: 2
-          attempt_delay: 0
+          attempt_delay: 60000
           with: |
             config-file: ${{inputs.MD_CONFIG}}
             use-quiet-mode: 'yes'

--- a/.github/workflows/pull_request_doc_qa.yaml
+++ b/.github/workflows/pull_request_doc_qa.yaml
@@ -23,13 +23,18 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{github.event.pull_request.head.sha}}
-      - name: Link check
-        uses: gaurav-nelson/github-action-markdown-link-check@v1
+      - name: Link checking with retries
+        uses: Wandalen/wretry.action@v3
         with:
-          config-file: ${{inputs.MD_CONFIG}}
-          use-quiet-mode: 'yes'
-          use-verbose-mode: 'yes'
-          max-depth: 3
+          action: gaurav-nelson/github-action-markdown-link-check@v1
+          retry_condition: steps._this.conclusion == 'failure'
+          attempt_limit: 2
+          attempt_delay: 0
+          with: |
+            config-file: ${{inputs.MD_CONFIG}}
+            use-quiet-mode: 'yes'
+            use-verbose-mode: 'yes'
+            max-depth: 3
 
   spell_check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Seems to work as expected, tested in https://github.com/stakater/support-docs/pull/38:

* It was failing temporarily for one link and ran twice: https://github.com/stakater/support-docs/actions/runs/13042066535/job/36385918703
  * Added a delay of 60 s to take into account that temporarily broken links might take some time to recover
* In a later run it was successful on first run and only ran once: https://github.com/stakater/support-docs/actions/runs/13042123457/job/36386087068