### PR TITLE
strip v from tag in folder name

### DIFF
--- a/.github/workflows/publish_operator_image_and_bundle.yaml
+++ b/.github/workflows/publish_operator_image_and_bundle.yaml
@@ -319,7 +319,9 @@ jobs:
         git fetch upstream
         git merge upstream/main
         git push --set-upstream origin main
-        git checkout -b ${{ github.event.repository.name }}-${{ needs.publish-image.outputs.latest_tag}}
+        LATEST_TAG="${{ needs.publish-image.outputs.latest_tag}}"
+        TAG_NO_V="${LATEST_TAG#v}"
+        git checkout -b ${{ github.event.repository.name }}-${LATEST_TAG}
 
         if stat "operators/${{ github.event.repository.name }}/ci.yaml" >/dev/null 2>&1; then
           echo "File exists: operators/${{ github.event.repository.name }}/ci.yaml"
@@ -338,12 +340,12 @@ jobs:
           echo "Wrote cert_project_id: $OPERATOR_BUNDLE_ID to operators/${{ github.event.repository.name }}/ci.yaml"
         fi
 
-        mkdir operators/${{ github.event.repository.name }}/${{ needs.publish-image.outputs.latest_tag}}
-        cp -R ../bundle/manifests operators/${{ github.event.repository.name }}/${{ needs.publish-image.outputs.latest_tag}}/manifests
-        cp -R ../bundle/metadata operators/${{ github.event.repository.name }}/${{ needs.publish-image.outputs.latest_tag}}/metadata
+        mkdir operators/${{ github.event.repository.name }}/${TAG_NO_V}
+        cp -R ../bundle/manifests operators/${{ github.event.repository.name }}/${TAG_NO_V}/manifests
+        cp -R ../bundle/metadata operators/${{ github.event.repository.name }}/${TAG_NO_V}/metadata
         git add .
-        git commit -am "Updated ${{ github.event.repository.name }} to ${{ needs.publish-image.outputs.latest_tag}}"
-        git push --set-upstream origin ${{ github.event.repository.name }}-${{ needs.publish-image.outputs.latest_tag}}
+        git commit -am "Updated ${{ github.event.repository.name }} to ${TAG_NO_V}"
+        git push --set-upstream origin ${{ github.event.repository.name }}-${LATEST_TAG}
 
     - name: Push changes
       uses: ad-m/github-push-action@master


### PR DESCRIPTION
Create version folder without V as per certified-operators instructions

https://github.com/redhat-openshift-ecosystem/operator-pipelines/pull/880

> ## Directory structure
> This repository contains an `operator` directory where all certified operators
> are stored. Each operator has its directory with its package name. Inside the directory,
> you have to provide a `ci.yaml` file that stores the necessary metadata for a successful
> certification process. The format of the file is described below.
> 
> ```bash
> operators
> └── kogito-operator
>     ├── 1.6.0
>     │   ├── manifests
>     │   │   ├── app.kiegroup.org_kogitobuilds.yaml
>     │   │   ├── app.kiegroup.org_kogitoinfras.yaml
>     │   │   ├── app.kiegroup.org_kogitoruntimes.yaml
>     │   │   ├── app.kiegroup.org_kogitosupportingservices.yaml
>     │   │   ├── kogito-operator.clusterserviceversion.yaml
>     │   │   └── kogito-operator-controller-manager_v1_serviceaccount.yaml
>     │   └── metadata
>     │       └── annotations.yaml
>     └── ci.yaml
> ```
> 
> ### Format of ci.yaml file
> In the file, user needs to provide necessary details for the operator certification process.
> Currently, the certification process supports the following options:
> 
> * `cert_project_id` - Identifier of certification project created through Red Hat Connect.
> * `merge` - A boolean value that determines whether a new operator is automatically
> merged when passed all required checks. (optional, default: `True`)
> 
> [ci-pipeline]:   https://github.com/redhat-openshift-ecosystem/operator-pipelines
> 