### PR TITLE
forward user/password secrets to the versioned-doc pre-build hook

### DIFF
--- a/.github/workflows/pull_request_versioned_doc.yaml
+++ b/.github/workflows/pull_request_versioned_doc.yaml
@@ -15,6 +15,12 @@ on:
       PRE_BUILD_TOKEN:
         description: "Secret to be used with PRE_BUILD_HOOK"
         required: false
+      PRE_BUILD_USER:
+        description: "Username available to PRE_BUILD_HOOK (e.g. a docs screenshot capture login)"
+        required: false
+      PRE_BUILD_PASSWORD:
+        description: "Password available to PRE_BUILD_HOOK"
+        required: false
     outputs:
       CURRENT_BRANCH:
         description: "Current head ref as a url friendly variable"
@@ -65,6 +71,8 @@ jobs:
         run: ${{ inputs.PRE_BUILD_HOOK }}
         env:
           PRE_BUILD_TOKEN: ${{ secrets.PRE_BUILD_TOKEN }}
+          PRE_BUILD_USER: ${{ secrets.PRE_BUILD_USER }}
+          PRE_BUILD_PASSWORD: ${{ secrets.PRE_BUILD_PASSWORD }}
       - name: Deploy PR docs
         run: mike deploy --push -b pull-request-deployments ${{ steps.current_branch.outputs.CURRENT_BRANCH }}
 

--- a/.github/workflows/push_versioned_doc.yaml
+++ b/.github/workflows/push_versioned_doc.yaml
@@ -20,6 +20,12 @@ on:
       PRE_BUILD_TOKEN:
         description: "Secret to be used with PRE_BUILD_HOOK"
         required: false
+      PRE_BUILD_USER:
+        description: "Username available to PRE_BUILD_HOOK (e.g. a docs screenshot capture login)"
+        required: false
+      PRE_BUILD_PASSWORD:
+        description: "Password available to PRE_BUILD_HOOK"
+        required: false
 
 jobs:
   push:
@@ -55,6 +61,8 @@ jobs:
         run: ${{ inputs.PRE_BUILD_HOOK }}
         env:
           PRE_BUILD_TOKEN: ${{ secrets.PRE_BUILD_TOKEN }}
+          PRE_BUILD_USER: ${{ secrets.PRE_BUILD_USER }}
+          PRE_BUILD_PASSWORD: ${{ secrets.PRE_BUILD_PASSWORD }}
 
       - name: Deploy content
         run: mike deploy --push ${{ github.ref_name }}


### PR DESCRIPTION
The pre-build hook only receives PRE_BUILD_TOKEN, so a hook needing any other credential can't get one: a caller cannot inject env into a reusable workflow (GitHub disallows env: on a job that uses one), and secrets: inherit doesn't help
because a secret must be referenced in the called workflow to become an env var.

Adds optional PRE_BUILD_USER and PRE_BUILD_PASSWORD secrets, forwarded to that step. Named secrets rather than one KEY=value blob so the interface stays explicit and other docs repos can reuse it.

Needed by mto-docs, whose pre-build hook captures live console screenshots.