### PR TITLE
fix/feat: fixed "helm-test" target

### DIFF
--- a/.github/actions/operator/chart-push/action.yaml
+++ b/.github/actions/operator/chart-push/action.yaml
@@ -24,6 +24,11 @@ inputs:
     required: false
     default: main
 
+  ENABLE_CHART_TESTS:
+    description: "Enable running helm chart tests"
+    required: false
+    default: false
+
   OPM_VERSION:
     description: OPM CLI version to use
     default: "v1.50.0"
@@ -40,6 +45,16 @@ runs:
       uses: azure/setup-helm@v4
       with:
         version: v3.12.3
+
+    - name: Run chart unit tests
+      if: ${{ inputs.ENABLE_CHART_TESTS }}
+      run: make helm-test
+      shell: bash
+      env:
+        VERSION: ${{ inputs.VERSION }}
+        GIT_TAG: ${{ inputs.TAG }}
+        HELM_REGISTRY: ${{ inputs.HELM_REGISTRY }}
+        DOCKER_REPO_BASE: ${{ inputs.CONTAINER_REGISTRY_URL }}
 
     - name: Build and push chart
       run: make helm-release

--- a/.github/makefiles/helm.mk
+++ b/.github/makefiles/helm.mk
@@ -72,7 +72,7 @@ HELM_UNITTEST_VERSION ?= 0.6.3
 .PHONY: helm-test
 helm-test: helmify install-helm ## Run helm unittest tests against the generated chart
 	@installed=$$($(HELM) plugin list 2>/dev/null | awk '$$1 == "unittest" { print $$2 }'); \
- 	if [ "$(printf '%s\n' "$(HELM_UNITTEST_VERSION)" "$$installed" | sort -V | head -n1)" = "$(HELM_UNITTEST_VERSION)" ]; then \
+ 	if [ "$$(printf '%s\n' "$(HELM_UNITTEST_VERSION)" "$$installed" | sort -V | head -n1)" = "$(HELM_UNITTEST_VERSION)" ]; then \
 		echo "helm unittest plugin v$(HELM_UNITTEST_VERSION) already installed (found: $${installed:-none}) - skipping install"; \
 	else \
 		echo "Installing helm unittest plugin v$(HELM_UNITTEST_VERSION) (found: $${installed:-none})..."; \

--- a/.github/makefiles/helm.mk
+++ b/.github/makefiles/helm.mk
@@ -71,11 +71,13 @@ HELM_UNITTEST_VERSION ?= 0.6.3
 
 .PHONY: helm-test
 helm-test: helmify install-helm ## Run helm unittest tests against the generated chart
-	@installed=$$($(HELM) plugin list 2>/dev/null | awk '$$1 == "unittest" { print $$2 }'); 
-	if [ "$$installed" != "$(HELM_UNITTEST_VERSION)" ]; then
-		echo "Installing helm unittest plugin v$(HELM_UNITTEST_VERSION) (found: $${installed:-none})..."; 
-		[ -n "$$installed" ] && $(HELM) plugin uninstall unittest >/dev/null 2>&1 || true; 
-		$(HELM) plugin install https://github.com/helm-unittest/helm-unittest --version $(HELM_UNITTEST_VERSION);
+	installed=$$($(HELM) plugin list 2>/dev/null | awk '$$1 == "unittest" { print $$2 }'); \
+ 	if [ "$(printf '%s\n' "$(HELM_UNITTEST_VERSION)" "$$installed" | sort -V | head -n1)" = "$(HELM_UNITTEST_VERSION)" ]; then \
+		echo "helm unittest plugin v$(HELM_UNITTEST_VERSION) already installed (found: $${installed:-none}) - skipping install"; \
+	else \
+		echo "Installing helm unittest plugin v$(HELM_UNITTEST_VERSION) (found: $${installed:-none})..."; \
+		[ -n "$$installed" ] && $(HELM) plugin uninstall unittest >/dev/null 2>&1 || true; \
+		$(HELM) plugin install https://github.com/helm-unittest/helm-unittest --version $(HELM_UNITTEST_VERSION) --verify=false; \
 	fi
 	$(HELM) unittest $(HELM_UNITTEST_ARGS) $(HELM_CHART_DIR)
 	@echo "✓ Helm chart tests passed!"

--- a/.github/makefiles/helm.mk
+++ b/.github/makefiles/helm.mk
@@ -71,7 +71,7 @@ HELM_UNITTEST_VERSION ?= 0.6.3
 
 .PHONY: helm-test
 helm-test: helmify install-helm ## Run helm unittest tests against the generated chart
-	installed=$$($(HELM) plugin list 2>/dev/null | awk '$$1 == "unittest" { print $$2 }'); \
+	@installed=$$($(HELM) plugin list 2>/dev/null | awk '$$1 == "unittest" { print $$2 }'); \
  	if [ "$(printf '%s\n' "$(HELM_UNITTEST_VERSION)" "$$installed" | sort -V | head -n1)" = "$(HELM_UNITTEST_VERSION)" ]; then \
 		echo "helm unittest plugin v$(HELM_UNITTEST_VERSION) already installed (found: $${installed:-none}) - skipping install"; \
 	else \

--- a/.github/workflows/operator_pull_request.yaml
+++ b/.github/workflows/operator_pull_request.yaml
@@ -45,6 +45,12 @@ on:
         default: false
         type: boolean
 
+      ENABLE_CHART_TESTS:
+        description: "Enable running helm chart tests"
+        required: false
+        default: false
+        type: boolean
+
       GIT_USER:
         description: "Git user to push changes"
         required: false
@@ -151,6 +157,7 @@ jobs:
         with:
           VERSION: ${{ steps.tag.outputs.TAG }}
           TAG: ${{ steps.tag.outputs.PR_TAG }}
+          ENABLE_CHART_TESTS: ${{ inputs.ENABLE_CHART_TESTS }}
           HELM_REGISTRY: "${{ secrets.CONTAINER_REGISTRY_URL }}/charts"
           CONTAINER_REGISTRY_URL: ${{ secrets.CONTAINER_REGISTRY_URL }}
         env:

--- a/.github/workflows/operator_push.yaml
+++ b/.github/workflows/operator_push.yaml
@@ -39,6 +39,12 @@ on:
         default: false
         type: boolean
 
+      ENABLE_CHART_TESTS:
+        description: "Enable running helm chart tests"
+        required: false
+        default: false
+        type: boolean
+
       ENABLE_CHART_PUSH:
         description: "Enable pushing helm charts to chart repo"
         required: false
@@ -168,6 +174,7 @@ jobs:
           HELM_REGISTRY: "${{ secrets.CONTAINER_REGISTRY_URL }}/charts"
           CONTAINER_REGISTRY_URL: ${{ secrets.CONTAINER_REGISTRY_URL }}
           LATEST_TAG_NAME: ${{ inputs.LATEST_TAG_NAME }}
+          ENABLE_CHART_TESTS: ${{ inputs.ENABLE_CHART_TESTS }}
         env:
           ADMIN_TOKEN: ${{ secrets.ADMIN_TOKEN }}
           GHCR_USERNAME: ${{ secrets.CONTAINER_REGISTRY_USERNAME }}

--- a/.github/workflows/operator_release.yaml
+++ b/.github/workflows/operator_release.yaml
@@ -51,6 +51,12 @@ on:
         default: false
         type: boolean 
 
+      ENABLE_CHART_TESTS:
+        description: "Enable running helm chart tests"
+        required: false
+        default: false
+        type: boolean
+
       ENABLE_CHART_PUSH:
         description: "Enable pushing helm charts to chart repo"
         required: false
@@ -185,6 +191,7 @@ jobs:
           TAG: ${{ steps.tag.outputs.PUSH_TAG }}
           HELM_REGISTRY: "${{ secrets.CONTAINER_REGISTRY_URL }}/charts"
           CONTAINER_REGISTRY_URL: ${{ secrets.CONTAINER_REGISTRY_URL }}
+          ENABLE_CHART_TESTS: ${{ inputs.ENABLE_CHART_TESTS }}
           LATEST_TAG_NAME: ${{ inputs.LATEST_TAG_NAME }}
         env:
           ADMIN_TOKEN: ${{ secrets.ADMIN_TOKEN }}
@@ -199,6 +206,7 @@ jobs:
           TAG: ${{ steps.tag.outputs.PUSH_TAG }}
           HELM_REGISTRY: "${{ secrets.CONTAINER_REGISTRY_URL }}/public/charts"
           CONTAINER_REGISTRY_URL: ${{ secrets.CONTAINER_REGISTRY_URL }}/public
+          ENABLE_CHART_TESTS: ${{ inputs.ENABLE_CHART_TESTS }}
 
         env:
           ADMIN_TOKEN: ${{ secrets.ADMIN_TOKEN }}


### PR DESCRIPTION
- `.github/makefiles/helm.mk` - target is now correct, and can run
- `.github/actions/operator/chart-push/action.yaml` - new input flag, step that runs "helm-test" target, before "helm-release".
- `.github/workflows/operator_pull_request.yaml` - new input flag, that is passed on to `chart-push`
- `.github/workflows/operator_push.yaml` - new input flag, that is passed on to `chart-push`
- `.github/workflows/operator_release.yaml` - new input flag, that is passed on to `chart-push`